### PR TITLE
adds multiple urls for vmalert

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -55,6 +55,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "vm-benchmark.nginxCached" -}}
-{{- $port := .Values.nodeExporter.service.hostPortCached | int }}
+{{- $port := .Values.nodeExporter.hostPortCached | int }}
 {{- printf "%s-exporter.%s.svc:%d" (include "vm-benchmark.fullname" .) .Release.Namespace $port }}
 {{- end }}

--- a/templates/nodeexporter/configmap.yaml
+++ b/templates/nodeexporter/configmap.yaml
@@ -24,7 +24,7 @@ data:
       uwsgi_temp_path /tmp/nginx 1 2;
       scgi_temp_path /tmp/nginx 1 2;
       server {
-        listen {{ .Values.nodeExporter.service.hostPortCached }};
+        listen {{ .Values.nodeExporter.hostPortCached }};
         server_name _;
         access_log off;
         error_log off;
@@ -34,7 +34,7 @@ data:
         keepalive_requests 1000;
 
         location / {
-          proxy_pass http://127.0.0.1:{{ .Values.nodeExporter.service.hostPort }};
+          proxy_pass http://127.0.0.1:{{ .Values.nodeExporter.hostPort }};
           proxy_cache all;
           proxy_cache_valid any 1s;
           proxy_cache_use_stale updating;

--- a/templates/nodeexporter/deployment.yaml
+++ b/templates/nodeexporter/deployment.yaml
@@ -6,16 +6,20 @@ metadata:
   labels:
   {{- include "vm-benchmark.labels" . | nindent 4 }}
 spec:
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
   {{- include "vm-benchmark.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/nodeexporter/configmap.yaml") . | sha256sum }}
       labels:
     {{- include "vm-benchmark.labels" . | nindent 8 }}
     spec:
       containers:
-        - name: {{ template "vm-benchmark.name" . }}-{{ .Values.nodeExporter.name }}
+        - name: nodeexporter
           image: "{{ .Values.nodeExporter.image.repository }}:{{ .Values.nodeExporter.image.tag }}"
           imagePullPolicy: "{{ .Values.nodeExporter.image.pullPolicy }}"
           args:
@@ -27,11 +31,10 @@ spec:
             - --no-collector.nfs
             - --collector.processes
             - --web.max-requests=40
-            - --web.listen-address=:{{ .Values.nodeExporter.service.hostPort }}
+            - --web.listen-address=:{{ .Values.nodeExporter.hostPort }}
           ports:
             - name: metrics
-              containerPort: {{ .Values.nodeExporter.service.hostPort }}
-              hostPort: {{ .Values.nodeExporter.service.hostPort }}
+              containerPort: {{ .Values.nodeExporter.hostPort }}
           resources:
 {{ toYaml .Values.nodeExporter.resources | indent 12 }}
           volumeMounts:
@@ -52,7 +55,7 @@ spec:
             - -c
             - /opt/nginx/nginx.conf
           ports:
-            - containerPort: {{ .Values.nodeExporter.service.hostPortCached }}
+            - containerPort: {{ .Values.nodeExporter.hostPortCached }}
               name: proxy
               protocol: TCP
           volumeMounts:

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -10,9 +10,9 @@ spec:
   selector:
   {{- include "vm-benchmark.labels" . | nindent 6 }}
   ports:
-    - port: {{ .Values.nodeExporter.service.hostPort }}
+    - port: {{ .Values.nodeExporter.hostPort }}
       name: exporter
-      targetPort: {{ .Values.nodeExporter.service.hostPort }}
-    - port: {{ .Values.nodeExporter.service.hostPortCached }}
+      targetPort: {{ .Values.nodeExporter.hostPort }}
+    - port: {{ .Values.nodeExporter.hostPortCached }}
       name: proxy
-      targetPort: {{ .Values.nodeExporter.service.hostPortCached }}
+      targetPort: {{ .Values.nodeExporter.hostPortCached }}

--- a/templates/vmagent/deployment.yaml
+++ b/templates/vmagent/deployment.yaml
@@ -11,15 +11,17 @@ spec:
   {{- include "vm-benchmark.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/vmagent/configmap.yaml") . | sha256sum }}
       labels:
-    {{- include "vm-benchmark.labels" . | nindent 8 }}
+    {{- include "vm-benchmark.selectorLabels" . | nindent 8 }}
     spec:
       containers:
-        - name: {{ template "vm-benchmark.name" . }}-{{ .Values.vmagent.name }}
+        - name: vmagent
           image: "{{ .Values.vmagent.image.repository }}:{{ .Values.vmagent.image.tag }}"
           imagePullPolicy: "{{ .Values.vmagent.image.pullPolicy }}"
           args:
-            - --httpListenAddr=:{{ .Values.vmagent.service.hostPort }}
+            - --httpListenAddr=:{{ .Values.vmagent.port }}
             - --promscrape.config=/config/scrape.yml
             {{- range .Values.vmagent.remoteWrite }}
             - --remoteWrite.url={{ .url }}
@@ -29,8 +31,7 @@ spec:
             {{- end }}
           ports:
             - name: metrics
-              containerPort: {{ .Values.vmagent.service.hostPort }}
-              hostPort: {{ .Values.vmagent.service.hostPort }}
+              containerPort: {{ .Values.vmagent.port }}
           resources:
 {{ toYaml .Values.vmagent.resources | indent 12 }}
           volumeMounts:

--- a/templates/vmalert/deployment.yaml
+++ b/templates/vmalert/deployment.yaml
@@ -1,77 +1,80 @@
 {{- if .Values.vmalert.enabled -}}
+{{ range $idx, $url := .Values.vmalert.urls }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "vm-benchmark.fullname" . }}-vmalert
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "vm-benchmark.fullname" $ }}-vmalert-{{ $idx}}
+  namespace: {{ $.Release.Namespace }}
   labels:
-  {{- include "vm-benchmark.labels" . | nindent 4 }}
+  {{- include "vm-benchmark.labels" $ | nindent 4 }}
 spec:
   selector:
     matchLabels:
-  {{- include "vm-benchmark.selectorLabels" . | nindent 6 }}
+  {{- include "vm-benchmark.selectorLabels" $ | nindent 6 }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/vmalert/vmalert-cm.yaml") $ | sha256sum }}
       labels:
-    {{- include "vm-benchmark.labels" . | nindent 8 }}
+   {{- include "vm-benchmark.selectorLabels" $ | nindent 8 }}
     spec:
       containers:
-        - name: {{ template "vm-benchmark.name" . }}-{{ .Values.vmalert.name }}
-          image: "{{ .Values.vmalert.image.repository }}:{{ .Values.vmalert.image.tag }}"
-          imagePullPolicy: "{{ .Values.vmalert.image.pullPolicy }}"
+        - name: vmalert
+          image: "{{ $.Values.vmalert.image.repository }}:{{ $.Values.vmalert.image.tag }}"
+          imagePullPolicy: "{{ $.Values.vmalert.image.pullPolicy }}"
           args:
-            - --httpListenAddr=:{{ .Values.vmalert.service.hostPort }}
-            - --notifier.url=http://127.0.0.1:{{ .Values.vmalert.service.amPort }}
+            - --httpListenAddr=:{{ $.Values.vmalert.port }}
+            - --notifier.url=http://127.0.0.1:{{ $.Values.vmalert.amPort }}
             - --rule=/config/alerts.yml
-            - --evaluationInterval={{ .Values.vmalert.evaluationInterval }}
-            - --datasource.url={{ .Values.vmalert.datasource.url }}
-            {{- if .Values.vmalert.datasource.token }}
-            - --datasource.bearerToken={{ .Values.vmalert.datasource.token }}
+            - --evaluationInterval={{ $.Values.vmalert.evaluationInterval }}
+            - --datasource.url={{ $url.datasource.url }}
+            {{- if $url.datasource.token }}
+            - --datasource.bearerToken={{ $url.datasource.token }}
             {{- end }}
-            {{- if .Values.vmalert.remoteWrite.url }}
-            - --remoteWrite.url={{ .Values.vmalert.remoteWrite.url }}
+            {{- if $url.remoteWrite.url }}
+            - --remoteWrite.url={{ $url.remoteWrite.url }}
             {{- end }}
-            {{- if .Values.vmalert.remoteWrite.token }}
-            - --remoteWrite.bearerToken={{ .Values.vmalert.remoteWrite.token }}
+            {{- if $url.remoteWrite.token }}
+            - --remoteWrite.bearerToken={{ $url.remoteWrite.token }}
           {{- end }}
           ports:
             - name: metrics
-              containerPort: {{ .Values.vmalert.service.hostPort }}
-              hostPort: {{ .Values.vmalert.service.hostPort }}
+              containerPort: {{ $.Values.vmalert.port }}
           resources:
-{{ toYaml .Values.vmalert.resources | indent 12 }}
+{{ toYaml $.Values.vmalert.resources | indent 12 }}
           volumeMounts:
             - name: vmalert-cfg
               mountPath: /config
 
-        - name: {{ template "vm-benchmark.name" . }}-alertmanager
+        - name: alertmanager
           image: prom/alertmanager
-          imagePullPolicy: "{{ .Values.vmalert.image.pullPolicy }}"
+          imagePullPolicy: "{{ $.Values.vmalert.image.pullPolicy }}"
           args:
-            - --web.listen-address=:{{ .Values.vmalert.service.amPort }}
+            - --web.listen-address=:{{ $.Values.vmalert.amPort }}
             - --config.file=/config/alertmanager.yml
           ports:
             - name: am
-              containerPort: {{ .Values.vmalert.service.amPort }}
-              hostPort: {{ .Values.vmalert.service.amPort }}
+              containerPort: {{ $.Values.vmalert.amPort }}
           resources:
-          {{ toYaml .Values.vmalert.resources | indent 12 }}
+          {{ toYaml $.Values.vmalert.resources | indent 12 }}
           volumeMounts:
             - name: alertmanager-cfg
               mountPath: /config
-      {{- if .Values.vmalert.tolerations }}
+      {{- if $.Values.vmalert.tolerations }}
       tolerations:
-{{ toYaml .Values.vmalert.tolerations | indent 8 }}
+{{ toYaml $.Values.vmalert.tolerations | indent 8 }}
       {{- end }}
-      {{- if .Values.vmalert.nodeSelector }}
+      {{- if $.Values.vmalert.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.vmalert.nodeSelector | indent 8 }}
+{{ toYaml $.Values.vmalert.nodeSelector | indent 8 }}
       {{- end }}
       volumes:
-      - name: vmalert-cfg
-        configMap:
-          name: {{ include "vm-benchmark.fullname" . }}-vmalert-cm
-      - name: alertmanager-cfg
-        configMap:
-          name: {{ include "vm-benchmark.fullname" . }}-alertmanager-cm
+        - name: vmalert-cfg
+          configMap:
+            name: {{ include "vm-benchmark.fullname" $ }}-vmalert-cm
+        - name: alertmanager-cfg
+          configMap:
+            name: {{ include "vm-benchmark.fullname" $ }}-alertmanager-cm
+---
+{{ end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -1,12 +1,10 @@
 ## List of configuration settings
 ## for vmagent deployment
 vmagent:
-  ## container name
-  name: "vmagent"
   image:
     repository: victoriametrics/vmagent
     pullPolicy: IfNotPresent
-    tag: "latest"
+    tag: "v1.72.0"
 
   ## targetsCount defines how many copies of nodeexporter
   ## to add as scrape targets.
@@ -26,26 +24,23 @@ vmagent:
       ## leave empty if no token configured
       token: ""
 
-  resources:
-    limits:
-      cpu: 2000m
-      memory: 2000Mi
-    requests:
-      cpu: 100m
-      memory: 100Mi
+  resources: { }
+#    limits:
+#      cpu: 2000m
+#      memory: 2000Mi
+#    requests:
+#      cpu: 100m
+#      memory: 100Mi
 
   nodeSelector: { }
   affinity: { }
   tolerations: [ ]
 
-  service:
-    hostPort: 8429
+  port: 8429
 
 ## List of configuration settings
 ## for nginx + nodeexporter deployment
 nodeExporter:
-  ## container name
-  name: "nodeexporter"
   image:
     repository: prom/node-exporter
     pullPolicy: IfNotPresent
@@ -61,30 +56,27 @@ nodeExporter:
 
   resources:
     limits:
-      cpu: 2000m
-      memory: 2000Mi
-    requests:
       cpu: 500m
       memory: 500Mi
+    requests:
+      cpu: 100m
+      memory: 100Mi
 
   nodeSelector: { }
   affinity: { }
   tolerations: [ ]
 
-  service:
-    ## port for nodeexporter to run
-    hostPort: 9101
-    ## port for nginx to run
-    ## vmagent will use this port for scraping
-    hostPortCached: 9102
+  ## port for nodeexporter to run
+  hostPort: 9101
+  ## port for nginx to run
+  ## vmagent will use this port for scraping
+  hostPortCached: 9102
 
 ## List of configuration settings
 ## for vmalert deployment
 vmalert:
   ## whether to deploy vmalert
   enabled: false
-  ## container name
-  name: "vmalert"
   image:
     repository: victoriametrics/vmalert
     pullPolicy: IfNotPresent
@@ -93,23 +85,23 @@ vmalert:
   ## how often to evaluate rules
   evaluationInterval: 30s
 
-  ## datasource defines address for rule execution
-  datasource:
-    ## single-node: http://<victoriametrics-addr>:8428
-    ## cluster: http://<vminsert-addr>:8481/select/0/prometheus
-    url: ""
-    ## auth token for VictoriaMetrics.
-    ## leave empty if no token configured
-    token: ""
-
-  ## remote-write configuration for vmalert
-  remoteWrite:
-    ## single-node: http://<victoriametrics-addr>:8428/api/v1/write
-    ## cluster: http://<vminsert-addr>:8480/insert/0/prometheus/
-    url: ""
-    ## auth token for VictoriaMetrics.
-    ## leave empty if no token configured
-    token: ""
+  # creates vmalert deployment per url
+  urls:
+    ## datasource defines address for rule execution
+    - datasource:
+        ## single-node: http://<victoriametrics-addr>:8428
+        ## cluster: http://<vminsert-addr>:8481/select/0/prometheus
+        url: ""
+        ## auth token for VictoriaMetrics.
+        ## leave empty if no token configured
+        token: ""
+      remoteWrite:
+        ## single-node: http://<victoriametrics-addr>:8428/
+        ## cluster: http://<vminsert-addr>:8480/insert/0/prometheus/
+        url: ""
+        ## auth token for VictoriaMetrics.
+        ## leave empty if no token configured
+        token: ""
 
   resources: { }
     # limits:
@@ -119,10 +111,11 @@ vmalert:
     #   cpu: 100m
     #   memory: 30Mi
 
-  nodeSelector: { }
+  nodeSelector: {}
   affinity: { }
   tolerations: [ ]
 
-  service:
-    hostPort: 8880
-    amPort: 9093
+  # vmalert port
+  port: 8880
+  # alertmanager port
+  amPort: 9093


### PR DESCRIPTION
removes uneeded hostPorts for vmalert, vmagent
adds checksum annotation for configmaps
changes deployment strategy for node exporter for Recreate - it must simplify config updates
removes service reference from ports, since it affects not only services
removes templated container names - it makes no sense to create different container names, its better to keep it static
removes resources limits from vmagent
changes limits for node exporter
https://github.com/VictoriaMetrics/rw-benchmark/issues/1